### PR TITLE
feat(content): adds relatedArticles feature

### DIFF
--- a/src/content/articles/2024/climbing-the-mountain/index.mdx
+++ b/src/content/articles/2024/climbing-the-mountain/index.mdx
@@ -13,6 +13,7 @@ description: In November of 2023 I traveled to Salento, Colombia for the adventu
 draft: false
 featured: true
 publishedAt: 01/08/2024
+relatedArticles: []
 tags:
   - colombia
 title: Climbing the Mountain
@@ -90,13 +91,13 @@ The guided climb began on Friday, November 10th at 0500 with a 22 kilometer hike
 	<small>The páramo that lay between Valle de Cocora and the summit.</small>
 </div>
 
-Day two was an easy ten kilometers to acclimate us to being 4,000 meters above sea level. Living outside of Bogotá I am roughly 2,600 meters above sea level so aclimating was not all the bad. I can not imagine coming from sea level or just above it to that height and not sufferring through altitude sickness. Our meals were the typical traditional Colombia cuisine: lots of rice, beans, a little meat, and plantains.
+Day two was an easy ten kilometers to acclimate us to being 4,000 meters above sea level. Living outside of Bogotá I am roughly 2,600 meters above sea level so acclimating was not all the bad. I can not imagine coming from sea level or just above it to that height and not suffering through altitude sickness. Our meals were the typical traditional Colombia cuisine: lots of rice, beans, a little meat, and plantains.
 
 We were told that we would be leaving for the summit at 2300 and to get as much rest as we could leading up to our departure and triple check our gear. It would take roughly seven to eight hours to reach the summit that was ten kilometers away and another 1,200 meters in altitude. I used to run quite a bit back in my younger days and the prospect that ten kilometers was going to take eight hours was a daunting reality check. The fastest time I clocked running ten kilometers was just over 33 minutes...so this, this was gonna be a whole other kind of suck.
 
 ## And so it begins
 
-We set out for the summit under a fairly clear sky that night. The moon was not all that visible as it was in it's waining phase; however the stars were out and visible. Unless we paused to rest there was no stopping to look at them as I needed my head lamp to illumintate the path before me that was ever changing. The night sky reminded me of my time in Afghanistan with how I could see the Milky Way in ways I had never seen it before. I would later be told the reasoning behind starting under the cover of darkness. I figured the reasoning was for those Instagram worthy sunrise photos from the summit, not quite:
+We set out for the summit under a fairly clear sky that night. The moon was not all that visible as it was in it's waning phase; however the stars were out and visible. Unless we paused to rest there was no stopping to look at them as I needed my head lamp to illuminate the path before me that was ever changing. The night sky reminded me of my time in Afghanistan with how I could see the Milky Way in ways I had never seen it before. I would later be told the reasoning behind starting under the cover of darkness. I figured the reasoning was for those Instagram worthy sunrise photos from the summit, not quite:
 
 > If we started you at dawn you would give up within an hour or two of starting because of the daunting task before you. Yeah sure you just walked for three hours and it looks like absolutely nothing changed in front of you. Your only gauge is too look back and that is just as disheartening to see how far you have traveled.
 
@@ -125,7 +126,7 @@ The four of us were tethered into one another with our guide Luisa at the helm. 
 
 It was roughly 0710 when we finally reached the summit of Nevado del Tolima. It was a complete white out at the top. Visibility was maybe 20-30 meters. Luisa told us she would give us about ten minutes to take pictures before we needed to begin our descent. I was frozen and exhausted, but I had not time to waste. I dropped my pack and went for the small pouch at the top where I had been carrying our dog Tommie's ashes. He never got the chance to know what snow was. This was my mission more than any kind of self discovery: letting go and saying goodbye to Tommie.
 
-Losing Tommie in August to what we believe was cancer so quickly left my wife and I reeling. We had seven days from the time we found out he had a mass the size of an orange closing off his colon to the time we had to put him down. His health declined so fast. He held on for us; it is clear to me now that he was trying to let us know it would be okay and it was his time to go. I used my pick axe to make a whole in the glacier and dumped half of his ashes into the hole covering it with snow while I cried telling him how much we loved him and missed him. The other half I let go on the wind while telling him goodbye. My tears were frozen to my face, but Tommie knew what snow was now. The guys I summited with never asked anything they just watched silently. Then we gathered for some quick photos. The three selfies I took quickly after spreading Tommie's ashes were quite funny. I believe it was the shudder having trouble with the cold so what I thought was a half frozen smile was the utter agony of cold, pain, and tears on my face. If I still had Instagram it would totally be a worthy shot for the Gram.
+Losing Tommie in August to what we believe was cancer so quickly left my wife and I reeling. We had seven days from the time we found out he had a mass the size of an orange closing off his colon to the time we had to put him down. His health declined so fast. He held on for us; it is clear to me now that he was trying to let us know it would be okay and it was his time to go. I used my pick axe to make a whole in the glacier and dumped half of his ashes into the hole covering it with snow while I cried telling him how much we loved him and missed him. The other half I let go on the wind while telling him goodbye. My tears were frozen to my face, but Tommie knew what snow was now. The guys I reached the summit with never asked anything they just watched silently. Then we gathered for some quick photos. The three selfies I took quickly after spreading Tommie's ashes were quite funny. I believe it was the shudder having trouble with the cold so what I thought was a half frozen smile was the utter agony of cold, pain, and tears on my face. If I still had Instagram it would totally be a worthy shot for the Gram.
 
 <div class='flex flex-col items-center gap-2'>
 <Image
@@ -162,7 +163,7 @@ I am a bad motherfucker and always have been. The shit I have been through in th
 
 Each step built upon the last to get me to the top of Nevado del Tolima. In the same way each decision we make daily builds upon the last to lead us to where we are at the end of every day, week, month, year, etc. A thought that ran through my head the whole trip was that "this will be over before you know it". I am 35, almost 36. How did that happen? I often think to myself "25 was not that long ago right"? Or "wow it has been four years since my wife and I were in Europe and I asked her to marry me". That saying "life comes at you fast" is beginning to really mean something as the years pile up.
 
-I certainly will never forget this experience. I have a tremendous amount of respect for anyone who says they have summited a mountain. It is no walk in the park and when I come to the realization that Mt. Everest would have been another 3,573 meters of altitude I think "yeah no, I am good with just this one summit!"
+I certainly will never forget this experience. I have a tremendous amount of respect for anyone who says they have reached the summit a mountain. It is no walk in the park and when I come to the realization that Mt. Everest would have been another 3,573 meters of altitude I think "yeah no, I am good with just this one summit!"
 
 <div class='flex flex-col items-center gap-2'>
 <Image

--- a/src/content/articles/2024/deploying-astro-to-fly/01-static-deployments.mdx
+++ b/src/content/articles/2024/deploying-astro-to-fly/01-static-deployments.mdx
@@ -1,7 +1,7 @@
 ---
 archived: false
 author: cody-brunner
-canonicalURL: https://blog.codybrunner.com/2024/deploying-astro-to-fly/part-1
+canonicalURL: https://blog.codybrunner.com/2024/deploying-astro-to-fly/static-deployments
 categories:
   - technology
 coverImage:
@@ -12,6 +12,10 @@ description: A quick how-to guide on deploying your static Astro projects to Fly
 draft: true
 featured: false
 publishedAt: 02/05/2024
+relatedArticles:
+  - 2024/deploying-astro-to-fly/ssr-deployments
+  - 2024/from-nextjs-to-astro
+slug: 2024/deploying-astro-to-fly/static-deployments
 tags:
   - astro
   - fly

--- a/src/content/articles/2024/deploying-astro-to-fly/02-ssr-deployments.mdx
+++ b/src/content/articles/2024/deploying-astro-to-fly/02-ssr-deployments.mdx
@@ -1,7 +1,7 @@
 ---
 archived: false
 author: cody-brunner
-canonicalURL: https://blog.codybrunner.com/2024/deploying-astro-to-fly/part-2
+canonicalURL: https://blog.codybrunner.com/2024/deploying-astro-to-fly/ssr-deployments
 categories:
   - technology
 coverImage:
@@ -12,6 +12,10 @@ description: A quick how-to guide on deploying your server-side rendered Astro p
 draft: true
 featured: false
 publishedAt: 02/12/2024
+relatedArticles:
+  - 2024/deploying-astro-to-fly/static-deployments
+  - 2024/from-nextjs-to-astro
+slug: 2024/deploying-astro-to-fly/ssr-deployments
 tags:
   - astro
   - fly

--- a/src/content/articles/2024/from-nextjs-to-astro/index.mdx
+++ b/src/content/articles/2024/from-nextjs-to-astro/index.mdx
@@ -12,6 +12,9 @@ description: In 2023 I began making the move from NextJS to Astro for my persona
 draft: false
 featured: true
 publishedAt: 01/15/2024
+relatedArticles:
+- 2024/deploying-astro-to-fly/ssr-deployments
+- 2024/deploying-astro-to-fly/static-deployments
 tags:
   - astro
   - nextjs

--- a/src/content/articles/2024/going-to-the-gopher-side/index.mdx
+++ b/src/content/articles/2024/going-to-the-gopher-side/index.mdx
@@ -12,6 +12,8 @@ description: The chaos that is the JavaScript/TypeScript ecosystem has become to
 draft: false
 featured: false
 publishedAt: 01/22/2024
+relatedArticles:
+	- 2024/working-with-makefiles
 tags:
   - go
   - javascript

--- a/src/content/articles/2024/working-with-makefiles/index.mdx
+++ b/src/content/articles/2024/working-with-makefiles/index.mdx
@@ -12,6 +12,8 @@ description: In my journey into learning Go I have been learning how to use Make
 draft: true
 featured: false
 publishedAt: 01/29/2024
+relatedArticles:
+	- 2024/going-to-the-gopher-side
 tags:
   - go
   - make

--- a/src/content/articles/markdown-style-guide.mdx
+++ b/src/content/articles/markdown-style-guide.mdx
@@ -10,6 +10,7 @@ description: lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusm
 draft: true
 featured: false
 language: en
+relatedArticles: []
 title: Markdown Style Guide
 ---
 

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -84,7 +84,7 @@ const articleSchema = z.object({
 		.string()
 		.transform(str => new Date(str))
 		.optional(),
-	relatedArticles: z.array(reference('articles')).optional(),
+	relatedArticles: z.array(reference('articles')).default([]),
 	tags: tagsSchema,
 	timeToRead: z.string().optional(),
 	title: z.string(),

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -4,15 +4,23 @@ import { getCollection, getEntry } from 'astro:content'
 
 import '~/styles/rehype-pretty-code.css'
 
+import Article from '~/components/article.astro'
 import Container from '~/components/container.astro'
 import Head from '~/components/head.astro'
 import Link from '~/components/link.astro'
-import type { Article } from '~/content/config'
+import type { Article as ArticleType } from '~/content/config'
 import BaseLayout from '~/layouts/base-layout.astro'
 import { formatDate, formatToDateTimeString } from '~/utils/strings'
-import { cn, isAfter, isPublished, sortArticles } from '~/utils/helpers'
+import {
+	cn,
+	filterArticles,
+	isAfter,
+	isPublished,
+	sortArticles,
+} from '~/utils/helpers'
 import Tag from '~/components/tag.astro'
 import Category from '~/components/category.astro'
+import { getEntries } from 'astro:content'
 
 export async function getStaticPaths() {
 	let articles = await getCollection('articles', article => {
@@ -31,11 +39,19 @@ export async function getStaticPaths() {
 	}))
 }
 
-export type Props = Article
+export type Props = ArticleType
 
 const { data: article, render } = Astro.props
+
 const { data: author } = await getEntry(article.author)
+let relatedArticles = await getEntries(article.relatedArticles)
+
+if (import.meta.env.MODE === 'production') {
+	relatedArticles = filterArticles(relatedArticles, isPublished)
+}
+
 const { Content, remarkPluginFrontmatter } = await render()
+
 const { timeToRead } = remarkPluginFrontmatter
 // TODO: Add back og:image override when CDN is configured
 /*
@@ -84,7 +100,9 @@ const { timeToRead } = remarkPluginFrontmatter
 						>
 							{article.title}
 						</h1>
-						<span class="text-primary-400 dark:text-primary-500 mt-1">{timeToRead}</span>
+						<span class='mt-1 text-primary-400 dark:text-primary-500'
+							>{timeToRead}</span
+						>
 						<time
 							class='order-first flex items-center text-base text-primary-400 dark:text-primary-500'
 							datetime={formatToDateTimeString(
@@ -126,6 +144,19 @@ const { timeToRead } = remarkPluginFrontmatter
 							</div>
 						)
 					}
+					{
+						relatedArticles.length > 0 && (
+							<div class='flex flex-col gap-8 pb-16'>
+								<h3 class='font-display text-3xl font-bold tracking-tight text-primary-800 sm:text-4xl dark:text-primary-100'>Related Articles</h3>
+								<hr class="border-primary-900/5 dark:border-white/10" />
+								<ul class='flex flex-col gap-16'>
+									{relatedArticles.map(({ data: article, slug }) => (
+										<Article article={article} slug={slug} />
+									))}
+								</ul>
+							</div>
+						)
+					}
 					<div
 						class='flex gap-4 rounded-xl p-6 shadow-lg shadow-primary-800/5 ring-1 ring-primary-900/5 dark:ring-white/10'
 					>
@@ -137,7 +168,7 @@ const { timeToRead } = remarkPluginFrontmatter
 								src={author.avatar}
 								width={120}
 							/>
-							<div class='flex items-center justify-center w-full gap-1'>
+							<div class='flex w-full items-center justify-center gap-1'>
 								<a
 									aria-label="Visit Cody Brunner's Buy Me A Coffee"
 									class='group h-6 w-6'


### PR DESCRIPTION
## What does this PR do?

- adds `relatedArticles` feature
- renames `deploying-astro-to-fly` series articles
- adds custom `slug` definition to the above articles
- adds `relatedArticles` property to all articles (default is `[]`)
- `relatedArticles` for `draft` status articles are filtered out in production.
- fixes typos in `Climbing the Mountain` article